### PR TITLE
Improved UI and improved jQM 1.4 compatibility

### DIFF
--- a/js/jqm-spinbox.js
+++ b/js/jqm-spinbox.js
@@ -104,8 +104,8 @@
 				w.d.inputWrap.css({'padding': 0});
 			}
 			
-			w.d.up = $('<div>').html('&nbsp;').buttonMarkup({icon: 'plus', iconpos: 'notext'});
-			w.d.down = $('<div>').html('&nbsp;').buttonMarkup({icon: 'minus', iconpos: 'notext'});
+			w.d.up = $('<div>', {'class': 'ui-btn ui-icon-plus ui-btn-icon-notext'}).html('&nbsp;');
+			w.d.down = $('<div>', {'class': 'ui-btn ui-icon-minus ui-btn-icon-notext'}).html('&nbsp;');
 			
 			if ( o.type === 'horizontal' ) {
 				w.d.down.prependTo(w.d.wrap); w.d.up.appendTo(w.d.wrap);


### PR DESCRIPTION
Hey Jonathan,

I've been using this plugin for a while. Now that we're upgrading our app to jQM 1.4, this plugin had to be upgraded as well. I didn't really like the UI of the current version, so I've tried to improve it.

In jQM 1.4, there's an [official workaround](http://demos.jquerymobile.com/1.4.3/controlgroup/#Textinputs) to make controlgroups containing text inputs. I've implemented this, and IMHO it looks better than the current UI.

Furthermore I made two other minor changes (which are documented in the commit messages).

Cheers,
Jonathan

P.S. I might try to make the textinput look more like a normal textinput (e.g., by having a white background). If the result is nice I'll make a PR for that as well.
