### PR TITLE
Improved disabled state once again

### DIFF
--- a/js/jqm-spinbox.js
+++ b/js/jqm-spinbox.js
@@ -223,8 +223,8 @@
 			var dis = this.d,
 				cname = "ui-state-disabled";
 			
-			dis.input.attr( "disabled", true );
-			dis.input.addClass( cname ).blur();
+			dis.input.attr( "disabled", true ).blur();
+			dis.inputWrap.addClass( cname );
 			dis.up.addClass( cname );
 			dis.down.addClass( cname );
 			this.options.disabled = true;
@@ -235,7 +235,7 @@
 				cname = "ui-state-disabled";
 			
 			dis.input.attr( "disabled", false );
-			dis.input.removeClass( cname );
+			dis.inputWrap.removeClass( cname );
 			dis.up.removeClass( cname );
 			dis.down.removeClass( cname );
 			this.options.disabled = false;

--- a/js/jqm-spinbox.js
+++ b/js/jqm-spinbox.js
@@ -86,6 +86,10 @@
 					o.theme
 				);
 			
+			if ( w.d.input.prop( "disabled" ) ) {
+				o.disabled = true;
+			}
+			
 			if ( o.dmin === false ) { 
 				o.dmin = ( typeof w.d.input.attr( "min" ) !== "undefined" ) ?
 					parseInt( w.d.input.attr( "min" ), 10 ) :

--- a/js/jqm-spinbox.js
+++ b/js/jqm-spinbox.js
@@ -209,7 +209,7 @@
 				});
 			}
 			
-			if ( w.disabled ) {
+			if ( o.disabled ) {
 				w.disable();
 			}
 			
@@ -223,7 +223,7 @@
 			dis.input.addClass( cname ).blur();
 			dis.up.addClass( cname );
 			dis.down.addClass( cname );
-			this.disabled = true;
+			this.options.disabled = true;
 		},
 		enable: function(){
 			// Enable the element
@@ -234,7 +234,7 @@
 			dis.input.removeClass( cname );
 			dis.up.removeClass( cname );
 			dis.down.removeClass( cname );
-			this.disabled = false;
+			this.options.disabled = false;
 		}
 	});
 })( jQuery );


### PR DESCRIPTION
Hey Jonathan,

Thanks for the quick acceptance of my previous PRs.

I've moved the `disabled` option to `options`, since this is common in jQM (e.g., in [textinput.js](https://github.com/jquery/jquery-mobile/blob/master/js/widgets/forms/textinput.js#L54)).

Furthermore I re-added support for disabling a spinbox before creation, which seems to got lost while merging my previous [commit](https://github.com/jtsage/jquery-mobile-spinbox/commit/da70d239d9bc434dd4b596b150fe674654401488). (Or did you remove it on purpose?)

Finally I made some changes the disable function which also probably [got lost](https://github.com/jtsage/jquery-mobile-spinbox/commit/1b8c878acaa96c534bc25dc4ac5bfa86a17bf79a).

Cheers,
Jonathan
